### PR TITLE
Unpins tfds-nightly in gpu extra which is in conflict with seqio's specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setuptools.setup(
             'best-download==0.0.9',
             'lm_dataformat==0.0.20',
             'dllogger@git+https://github.com/NVIDIA/dllogger#egg=dllogger',
-            'tfds-nightly==4.6.0.dev202210040045',
+            'tfds-nightly',
             't5==0.9.4',
         ],
     },


### PR DESCRIPTION
Currently the version of tfds-nightly pinned by the gpu extra is in conflict with the one pinned in seqio. This change will unpin tfds-nightly in the gpu extra to allow installing t5x with the gpu extra. For reference, the error encountered was:

```
29.57 The conflict is caused by:
29.57     t5x[gpu] 0.0.0 depends on tfds-nightly==4.6.0.dev202210040045
29.57     t5 0.9.4 depends on tfds-nightly
29.57     seqio 0.0.17 depends on tfds-nightly==4.9.2.dev202308090034
```