### PR TITLE
Adds ENABLE_TE env var and renames TEConfig.enabled -> TEConfig.enable_fp8

### DIFF
--- a/t5x/contrib/gpu/scripts_gpu/multiprocess_ft_frompile.sh
+++ b/t5x/contrib/gpu/scripts_gpu/multiprocess_ft_frompile.sh
@@ -72,10 +72,6 @@ case $FT_TASK in
     ;;
 esac
 
-if [[ -n "${UNINSTALL_TE:-}" && ${UNINSTALL_TE:-} -ne 0 ]]; then
-  pip uninstall -y transformer_engine
-fi
-
 # Global batch size
 BSIZE=$(( GPUS_PER_NODE * BSIZE_PER_GPU * SLURM_JOB_NUM_NODES / TP_SIZE))
 export GPU_DEVICES=$(seq -s, 0 $((GPUS_PER_NODE - 1)) )

--- a/t5x/contrib/gpu/scripts_gpu/multiprocess_ft_frompile.sh
+++ b/t5x/contrib/gpu/scripts_gpu/multiprocess_ft_frompile.sh
@@ -105,7 +105,7 @@ python3 -u ${T5X_DIR}/t5x/train.py \
   --gin.train.eval_period=1000 \
   --gin.train.gc_period=2000 \
   --gin.train.te_config_cls=@te_helper.TransformerEngineConfig \
-  --gin.te_helper.TransformerEngineConfig.enabled=${ENABLE_FP8} \
+  --gin.te_helper.TransformerEngineConfig.enable_fp8=${ENABLE_FP8} \
   --gin.te_helper.TransformerEngineConfig.fp8_format=\"hybrid\" \
   --gin.network.T5Config.transpose_batch_sequence=${TRANSPOSE_BS} \
   --gin.network.T5Config.fuse_qkv_params=${FUSE_QKV} \

--- a/t5x/contrib/gpu/scripts_gpu/multiprocess_pretrain_pile.sh
+++ b/t5x/contrib/gpu/scripts_gpu/multiprocess_pretrain_pile.sh
@@ -95,7 +95,7 @@ python3 ${T5X_DIR}/t5x/train.py \
   --gin.train.eval_period=1000 \
   --gin.train.gc_period=${TRAIN_STEPS} \
   --gin.train.te_config_cls=@te_helper.TransformerEngineConfig \
-  --gin.te_helper.TransformerEngineConfig.enabled=${ENABLE_FP8} \
+  --gin.te_helper.TransformerEngineConfig.enable_fp8=${ENABLE_FP8} \
   --gin.te_helper.TransformerEngineConfig.fp8_format=\"hybrid\" \
   --gin.network.T5Config.transpose_batch_sequence=${TRANSPOSE_BS} \
   --gin.network.T5Config.fuse_qkv_params=${FUSE_QKV} \

--- a/t5x/contrib/gpu/scripts_gpu/singlenode_ft_frompile.sh
+++ b/t5x/contrib/gpu/scripts_gpu/singlenode_ft_frompile.sh
@@ -86,7 +86,7 @@ python3 -u ${T5X_DIR}/t5x/train.py \
   --gin.train/utils.DatasetConfig.pack=${PACK} \
   --gin.train_eval/utils.DatasetConfig.pack=${PACK} \
   --gin.train.te_config_cls=@te_helper.TransformerEngineConfig \
-  --gin.te_helper.TransformerEngineConfig.enabled=${ENABLE_FP8} \
+  --gin.te_helper.TransformerEngineConfig.enable_fp8=${ENABLE_FP8} \
   --gin.te_helper.TransformerEngineConfig.fp8_format=\"hybrid\" \
   --gin.network.T5Config.transpose_batch_sequence=${TRANSPOSE_BS} \
   --gin.network.T5Config.fuse_qkv_params=${FUSE_QKV} \

--- a/t5x/contrib/gpu/scripts_gpu/singlenode_pretrain_pile.sh
+++ b/t5x/contrib/gpu/scripts_gpu/singlenode_pretrain_pile.sh
@@ -58,7 +58,7 @@ python3 -u ${T5X_DIR}/t5x/train.py \
   --gin.train/utils.DatasetConfig.pack=${PACK} \
   --gin.train_eval/utils.DatasetConfig.pack=${PACK} \
   --gin.train.te_config_cls=@te_helper.TransformerEngineConfig \
-  --gin.te_helper.TransformerEngineConfig.enabled=${ENABLE_FP8} \
+  --gin.te_helper.TransformerEngineConfig.enable_fp8=${ENABLE_FP8} \
   --gin.te_helper.TransformerEngineConfig.fp8_format=\"hybrid\" \
   --gin.network.T5Config.transpose_batch_sequence=${TRANSPOSE_BS} \
   --gin.network.T5Config.fuse_qkv_params=${FUSE_QKV} \

--- a/t5x/te_helper.py
+++ b/t5x/te_helper.py
@@ -15,16 +15,20 @@ from absl import logging
 from contextlib import contextmanager
 import gin
 import jax
+import os
+
+logging.set_verbosity(logging.INFO)
 
 try:
   from transformer_engine.common.recipe import DelayedScaling
   from transformer_engine.common.recipe import Format as FP8Format
   import transformer_engine.jax as te
   _IS_TRANSFORMER_ENGINE_INSTALLED = True
+  logging.info('Transformer Engine is installed')
 
 except ModuleNotFoundError as e:
   _IS_TRANSFORMER_ENGINE_INSTALLED = False
-
+  logging.info('Transformer Engine is not installed')
 
 def _canonicalize_fp8_format(fp8_format):
   if not _IS_TRANSFORMER_ENGINE_INSTALLED:
@@ -243,10 +247,14 @@ class TEInstalledHelper(TransformerEngineHelperBase):
 
 
 class TransformerEngineHelper(TransformerEngineHelperBase):
+  @staticmethod
+  def is_enabled_te():
+    enable_te = bool(int((os.environ.get("ENABLE_TE", False))))
+    return (_IS_TRANSFORMER_ENGINE_INSTALLED and enable_te)
 
   @staticmethod
   def get_helper():
-    if _IS_TRANSFORMER_ENGINE_INSTALLED:
+    if TransformerEngineHelper.is_enabled_te():
       return TEInstalledHelper
     return TENotInstalledHelper
 

--- a/t5x/te_helper.py
+++ b/t5x/te_helper.py
@@ -46,17 +46,17 @@ def _canonicalize_fp8_format(fp8_format):
 
 @gin.configurable
 class TransformerEngineConfig:
-  def __init__(self, enabled=False, fp8_format='fp8_hybrid', margin=0., amax_history_len=1024):
-    assert (_IS_TRANSFORMER_ENGINE_INSTALLED or (not enabled)), \
+  def __init__(self, enable_fp8=False, fp8_format='fp8_hybrid', margin=0., amax_history_len=1024):
+    assert (_IS_TRANSFORMER_ENGINE_INSTALLED or (not enable_fp8)), \
         'Attempt to run transformer engine FP8 without installing transformer_engine.'
 
-    self.enabled = enabled
+    self.enable_fp8 = enable_fp8
     self.fp8_format = _canonicalize_fp8_format(fp8_format)
     self.margin = margin
     self.amax_history_len = amax_history_len
 
   def __str__(self):
-    return f"TransformerEngineConfig: enabled:{self.enabled}," \
+    return f"TransformerEngineConfig: enable_fp8:{self.enable_fp8}," \
            f" fp8_format: {self.fp8_format}, margin: {self.margin}," \
            f" amax_history_len: {self.amax_history_len}."
 
@@ -162,7 +162,7 @@ class TEInstalledHelper(TransformerEngineHelperBase):
                                    amax_history_len=te_config.amax_history_len,
                                    amax_compute_algo="max")
     try:
-      with te.fp8_autocast(enabled=te_config.enabled, fp8_recipe=delay_scaling,
+      with te.fp8_autocast(enabled=te_config.enable_fp8, fp8_recipe=delay_scaling,
                            sharding_resource=te.ShardingResource(dp_mesh_axis, tp_mesh_axis)):
         yield
     finally:


### PR DESCRIPTION
* `ENABLE_TE` allows a user to disable TE without having to uninstall, which was observed to have issues when multiple processes tried to uninstall in parallel
* renamed `enabled` kwarg/property to `enable_fp8` to be more consistent with pax, and avoid confusion between this arg and the `ENABLE_TE` env var