### PR TITLE
Force initial flax mutables to be a frozen dict

### DIFF
--- a/t5x/trainer.py
+++ b/t5x/trainer.py
@@ -684,7 +684,7 @@ def accumulate_grads_microbatched(
   # them and return flax_mutables from `get_initial_variables` and `loss_fn`.
 
   initial_flax_mutables = (
-      train_state.flax_mutables if train_state.flax_mutables else {}
+      train_state.flax_mutables if train_state.flax_mutables else FrozenDict({})
   )
 
   if num_microbatches is None or num_microbatches <= 1:


### PR DESCRIPTION
This fixes a bug when using gradient accumulation that is caused by `initial_flax_mutables` and FlaxOptimTrainState's [flax_mutables](https://github.com/google-research/t5x/blob/1bfd2f15e5e77b09d60301367f67fdc9bb756b46/t5x/train_state.py#L122) being different types. 